### PR TITLE
Fix user role check

### DIFF
--- a/server/src/models/user.js
+++ b/server/src/models/user.js
@@ -79,7 +79,7 @@ const userSchema = Schema(
 userSchema.methods.toJSON = function() {
   const user = this;
   const userObject = user.toObject();
-  if (!userObject.role === 'superadmin') {
+  if (userObject.role !== 'superadmin') {
     delete userObject.updatedAt;
     delete userObject.__v;
   }


### PR DESCRIPTION
## Summary
- fix logic for hiding fields when user is not a superadmin

## Testing
- `npx eslint server/src/models/user.js` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6841d92a3c7c83249f92be2131573f9c