### PR TITLE
Fix clone URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ $ Ознакомьтесь с примером .env
 Установите зависимости и devDependencies
 
 ```sh
-$ git clone https://github.com/georgesimos/Movie-app.git
+$ git clone https://github.com/georgesimos/cinema-plus.git
 $ npm install
 $ cd server npm install && npm start
 $ cd client npm install && npm start


### PR DESCRIPTION
## Summary
- correct the repository link in `README.md`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6841d92c68dc832499a71228d3a844f7