### PR TITLE
Improve user validation

### DIFF
--- a/client/src/pages/Admin/Account/components/AccountDetails/AccountDetails.js
+++ b/client/src/pages/Admin/Account/components/AccountDetails/AccountDetails.js
@@ -20,7 +20,8 @@ class Account extends Component {
     email: '',
     phone: '',
     password: '',
-    phoneError: ''
+    phoneError: '',
+    emailError: ''
   };
 
   componentDidMount() {
@@ -33,13 +34,21 @@ class Account extends Component {
     return phoneRegex.test(phone);
   };
 
+  validateEmail = email => {
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    return emailRegex.test(email);
+  };
+
   handleFieldChange = (field, value) => {
     const newState = { ...this.state };
     newState[field] = value;
     
-    // Очищаем ошибку при изменении номера
+    // Очищаем ошибку при изменении номера или email
     if (field === 'phone') {
       newState.phoneError = '';
+    }
+    if (field === 'email') {
+      newState.emailError = '';
     }
     
     this.setState(newState);
@@ -51,8 +60,16 @@ class Account extends Component {
 
       // Проверяем формат телефона перед отправкой
       if (phone && !this.validatePhoneNumber(phone)) {
-        this.setState({ 
-          phoneError: 'Введите номер в формате +7XXXXXXXXXX' 
+        this.setState({
+          phoneError: 'Введите номер в формате +7XXXXXXXXXX'
+        });
+        return;
+      }
+
+      // Проверяем формат email перед отправкой
+      if (email && !this.validateEmail(email)) {
+        this.setState({
+          emailError: 'Некорректный email'
         });
         return;
       }
@@ -113,6 +130,8 @@ class Account extends Component {
                 required
                 value={email}
                 variant="outlined"
+                error={!!this.state.emailError}
+                helperText={this.state.emailError}
                 onChange={event =>
                   this.handleFieldChange('email', event.target.value)
                 }

--- a/client/src/pages/Admin/User/components/AddUser/AddUser.js
+++ b/client/src/pages/Admin/User/components/AddUser/AddUser.js
@@ -14,7 +14,9 @@ class AddUser extends Component {
     email: '',
     password: '',
     role: '',
-    phone: ''
+    phone: '',
+    phoneError: '',
+    emailError: ''
   };
 
   componentDidMount() {
@@ -38,6 +40,16 @@ class AddUser extends Component {
     }
   }
 
+  validatePhoneNumber = phone => {
+    const phoneRegex = /^\+7\d{10}$/;
+    return phoneRegex.test(phone);
+  };
+
+  validateEmail = email => {
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    return emailRegex.test(email);
+  };
+
   handleChange = e => {
     this.setState({
       state: e.target.value
@@ -47,15 +59,49 @@ class AddUser extends Component {
   handleFieldChange = (field, value) => {
     const newState = { ...this.state };
     newState[field] = value;
+    if (field === 'phone') newState.phoneError = '';
+    if (field === 'email') newState.emailError = '';
     this.setState(newState);
   };
 
   onAddUser = () => {
+    const { phone, email } = this.state;
+
+    let hasError = false;
+
+    if (phone && !this.validatePhoneNumber(phone)) {
+      this.setState({ phoneError: 'Введите номер в формате +7XXXXXXXXXX' });
+      hasError = true;
+    }
+
+    if (email && !this.validateEmail(email)) {
+      this.setState({ emailError: 'Некорректный email' });
+      hasError = true;
+    }
+
+    if (hasError) return;
+
     const user = { ...this.state };
     this.props.addUser(user);
   };
 
   onUpdateUser = () => {
+    const { phone, email } = this.state;
+
+    let hasError = false;
+
+    if (phone && !this.validatePhoneNumber(phone)) {
+      this.setState({ phoneError: 'Введите номер в формате +7XXXXXXXXXX' });
+      hasError = true;
+    }
+
+    if (email && !this.validateEmail(email)) {
+      this.setState({ emailError: 'Некорректный email' });
+      hasError = true;
+    }
+
+    if (hasError) return;
+
     const user = { ...this.state };
     this.props.updateUser(user, this.props.selectedUser._id);
   };
@@ -117,6 +163,8 @@ class AddUser extends Component {
               required
               value={email}
               variant="outlined"
+              error={!!this.state.emailError}
+              helperText={this.state.emailError}
               onChange={event =>
                 this.handleFieldChange('email', event.target.value)
               }
@@ -143,6 +191,9 @@ class AddUser extends Component {
               required
               value={phone}
               variant="outlined"
+              placeholder="+7XXXXXXXXXX"
+              error={!!this.state.phoneError}
+              helperText={this.state.phoneError}
               onChange={event =>
                 this.handleFieldChange('phone', event.target.value)
               }


### PR DESCRIPTION
## Summary
- add phone/email validation in AddUser form
- improve account form to validate phone and email on update

## Testing
- `npm install` & `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841dd11acf0832496f7f21e14befea9